### PR TITLE
Translations are deleted upon activation

### DIFF
--- a/src/zabapgit_objects.prog.abap
+++ b/src/zabapgit_objects.prog.abap
@@ -1461,23 +1461,30 @@ CLASS lcl_objects_program IMPLEMENTATION.
     ENDIF.
 
     READ TABLE it_tpool WITH KEY id = 'R' TRANSPORTING NO FIELDS.
-    IF ( sy-subrc = 0 AND lines( it_tpool ) = 1 ) OR lines( it_tpool ) = 0.
-      RETURN. " no action for includes
+    IF ( sy-subrc = 0 AND lines( it_tpool ) = 1 AND lv_language = mv_language ) OR lines( it_tpool ) = 0.
+      RETURN. " no action for includes unless there is a translation of the program description
     ENDIF.
 
-    INSERT TEXTPOOL iv_program
-      FROM it_tpool
-      LANGUAGE lv_language
-      STATE 'I'.
-    IF sy-subrc <> 0.
-      zcx_abapgit_exception=>raise( 'error from INSERT TEXTPOOL' ).
-    ENDIF.
+    IF lv_language = mv_language. "Textpool in master language needs to be activated
+      INSERT TEXTPOOL iv_program
+        FROM it_tpool
+        LANGUAGE lv_language
+        STATE 'I'.
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise( 'error from INSERT TEXTPOOL' ).
+      ENDIF.
 
-    IF lv_language = mv_language. " Add just once
       lcl_objects_activation=>add( iv_type = 'REPT'
                                    iv_name = iv_program ).
+    ELSE. "Translations are always active
+      INSERT TEXTPOOL iv_program
+        FROM it_tpool
+        LANGUAGE lv_language
+        STATE 'A'.
+      IF sy-subrc <> 0.
+        zcx_abapgit_exception=>raise( 'error from INSERT TEXTPOOL' ).
+      ENDIF.
     ENDIF.
-
   ENDMETHOD.                    "deserialize_textpool
 
   METHOD deserialize_cua.


### PR DESCRIPTION
Translations should be inserted as active text pools, only the text pool of the master language can be inactive. Otherwise translations will be deleted upon activation.